### PR TITLE
Corregida la detección de la uri en mtv.es

### DIFF
--- a/Script/uiDescargar.py
+++ b/Script/uiDescargar.py
@@ -84,8 +84,17 @@ class Descargar(object):
         printt(u"\n[INFO] Presiona \"Ctrl + C\" para cancelar\n")
         
         # TODO: mejorar esto!
-        args = self.__COMANDO_RTMPD.split() if self.__COMANDO_RTMPD is not None else self.__COMANDO_MENCO.split()
-        
+        old_args = self.__COMANDO_RTMPD.split() if self.__COMANDO_RTMPD is not None else self.__COMANDO_MENCO.split()
+        args = []
+        # Clean the command args
+        for arg in old_args:
+            new_arg = arg
+            first_char = arg[0]
+            # The arguments cannot be enclosed in ' or " when passing them to subprocess
+            if first_char in ['\'', '"'] and first_char == arg[-1]:
+                new_arg = arg[1:-1]
+            args.append(new_arg)
+
         try:
             printt(u"\nLanzando rtmpdump...\n")
             out = subprocess.call(args)

--- a/spaintvs/mtv.py
+++ b/spaintvs/mtv.py
@@ -92,7 +92,7 @@ class MTV(Canal.Canal):
         html = Descargar.get(self.url)
         html = html.replace("\n", "").replace("\t", "")
         try: #ES
-            uri = html.split("var uri = \"")[1].split("\"")[0]
+            uri = html.split("data-contenturi=\"")[1].split("\"")[0]
         except: #COM
             com = True
             uri = html.split(".videoUri = \"")[1].split("\"")[0]


### PR DESCRIPTION
No sé si soluciona #43

He añadido un trozo de código en uiDescargar.py para eliminal las comillas (`'` o `"`) iniciales y finales de los argumentos que se pasaban a rtmpdump, sino rtmpdump daba un error diciendo que no reconocía el protocolo (recibía la url como `'rtmpe://...'`)
