### PR TITLE
Update aragontv.py

### DIFF
--- a/spaintvs/aragontv.py
+++ b/spaintvs/aragontv.py
@@ -115,6 +115,9 @@ class AragonTV(Canal.Canal):
                 
             if name: name = Utiles.formatearNombre(name)
             rtmpd_cmd = "rtmpdump -r "+url+" -o "+name
+            
+            # se obtiene un enlace MP4 al coger el url sin mp4: y ponerle como server 
+            # http://alacarta.aragontelevision.es/_archivos/videos
         except:
             raise Error.GeneralPyspainTVsError(u"Error al recuperar el vídeo de Aragon TV")
     


### PR DESCRIPTION
Aabilio,

en Aragón se pueden obtener enlaces MP4 directos. Del playpath del rtmp quédate con la parte sin el mp4: y añádele http://alacarta.aragontelevision.es/_archivos/videos
